### PR TITLE
fix: correct navbar logo alt text

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -3,7 +3,7 @@
 		<div class="sm:flex sm:justify-between items-center sm:items-center sm:px-4 sm:pt-3 sm:pb-2 max-w-7xl w-1/1">
 			<div class="flex items-center justify-between px-4 py-2 sm:p-0">
 			<div>
-			<img class="h-16" src="../assets/images/mauros-logo-v1.svg" alt="Mauro website Offical Logo" >
+			<img class="h-16" src="../assets/images/mauros-logo-v1.svg" alt="Mauro website Official Logo" >
 		</div>
 		<div class="sm:hidden">
 			<button @click="isOpen = !isOpen" type="button" class="flex justify-center items-center bg-gray-900 text-gray-500 focus:outline-none w-6 h-6 rounded-sm">


### PR DESCRIPTION
## Summary
- fix spelling of navbar logo alt text to "Official"

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b7101a8708331aa197045f4bc57c0