### PR TITLE
Add Vitest setup and Navbar tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.6",
@@ -15,6 +16,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.6.0",
+    "@vue/test-utils": "^2.4.3",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/Navbar.spec.js
+++ b/tests/Navbar.spec.js
@@ -1,0 +1,35 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import Navbar from '../src/components/Navbar.vue';
+
+describe('Navbar', () => {
+  it('toggles menu and icon on button click', async () => {
+    const wrapper = mount(Navbar);
+
+    expect(wrapper.vm.isOpen).toBe(false);
+    expect(wrapper.find('.fa-bars').exists()).toBe(true);
+    expect(wrapper.find('.fa-xmark-large').exists()).toBe(false);
+
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.vm.isOpen).toBe(true);
+    expect(wrapper.find('.fa-bars').exists()).toBe(false);
+    expect(wrapper.find('.fa-xmark-large').exists()).toBe(true);
+  });
+
+  it('scrolls to section on navBarClick', async () => {
+    const scrollIntoView = vi.fn();
+    const getElementById = vi.spyOn(document, 'getElementById').mockReturnValue({
+      scrollIntoView,
+    });
+
+    const wrapper = mount(Navbar);
+
+    await wrapper.find('#projects').trigger('click');
+
+    expect(getElementById).toHaveBeenCalledWith('projects-section');
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+    getElementById.mockRestore();
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,5 +14,8 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
-  }, 
+  },
+  test: {
+    environment: 'jsdom'
+  },
 })


### PR DESCRIPTION
## Summary
- add Vitest and Vue Test Utils dev dependencies and test script
- configure Vite to run tests in a jsdom environment
- implement Navbar unit tests for menu toggle and section scrolling

## Testing
- `npm install --save-dev vitest @vue/test-utils jsdom` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b7d9cbbe4833188605ec389111831